### PR TITLE
Add support for handling query parameters without values

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -50,7 +50,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/v')
       run: dotnet nuget push src/*/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_TOKEN }}
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v4
       with:
         name: artifacts
         path: artifacts

--- a/src/LtiLibrary.NetCore/Common/UrlEncodingParser.cs
+++ b/src/LtiLibrary.NetCore/Common/UrlEncodingParser.cs
@@ -96,6 +96,10 @@ namespace LtiLibrary.NetCore.Common
                     {
                         Add(pair.Substring(0, index2), pair.Substring(index2 + 1));
                     }
+                    else
+                    {
+                        Add(pair, "");
+                    }
                 }
             }
 

--- a/test/LtiLibrary.NetCore.Tests/LtiRequestShould.cs
+++ b/test/LtiLibrary.NetCore.Tests/LtiRequestShould.cs
@@ -265,6 +265,28 @@ namespace LtiLibrary.NetCore.Tests
             var signature = request.GenerateSignature("secret");
             Assert.Equal(expectedSignature, signature);
         }
+        
+        [Theory]
+        [InlineData("HMAC-SHA1", "Dp8HRLM0OrWFVXwtzJVKCGV9aEM=")]
+        [InlineData("HMAC-SHA256", "w3gXRIoBPBEsXBQdFRc9DYsCXcp+k0yF/Zw+mW83uf8=")]
+        [InlineData("HMAC-SHA384", "pjJZpR+++g+mwqsRqbbNKUUdaaFA/gCXfXq5qCunJCmzkapKOYlqTq5r10mBlKQQ")]
+        [InlineData("HMAC-SHA512", "SJYrwBY6lthjf1IjttSbatoVLi942i0S7EXDKYIBIyD7eYE0fBzj+jELXouZP1KGqW4gCCvf+DX9oYfJfydRxQ==")]
+        public void GenerateKnownSignature_LaunchUrlWithQueryString_IncludesQueryString(string signatureMethod, string expectedSignature)
+        {
+            var request = new LtiRequest
+            {
+                BodyHash = "zxNf/lJoveI1hmN1ENbcdZdQ4Js=",
+                ConsumerKey = "jisc.ac.uk",
+                HttpMethod = HttpMethod.Post.Method,
+                Nonce = "83e29bff47b7690a3f6b371c77526405",
+                SignatureMethod = signatureMethod,
+                Timestamp = 1493164209,
+                Url = new Uri("http://lti.tools/test/tc-outcomes.php?lti-tool"),
+                Version = "1.0"
+            };
+            var signature = request.GenerateSignature("secret");
+            Assert.Equal(expectedSignature, signature);
+        }
 
         #endregion
 


### PR DESCRIPTION
Updated `UrlEncodingParser` to allow adding query parameters with empty values. Added test cases to verify signature generation for URLs with query strings, using multiple HMAC algorithms.
Fixes #154 